### PR TITLE
enable CONFIG_IPV6_MROUTE_MULTIPLE_TABLES for wireguard ipv6

### DIFF
--- a/network.config
+++ b/network.config
@@ -20,6 +20,7 @@ CONFIG_BRIDGE_MRP=y
 CONFIG_BRIDGE_CFM=y
 # disable sit0 at boot
 CONFIG_IPV6_SIT=m
+CONFIG_IPV6_MULTIPLE_TABLES=y
 
 # traffic schedulers
 CONFIG_NET_SCHED=y


### PR DESCRIPTION
This config adds default ipv6 rules.

Verified using `ip -6 rule`.